### PR TITLE
Use cross-env for universal environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,6 @@ $ cd "project name" && npm run start
 
 You may need to install [nodemon](https://www.npmjs.com/package/nodemon) separately if you do not currently have it installed on your machine.
 
-NOTE: If you are running this on a Windows machine, you will need to update the `npm run start` and `npm run dev` script commands as follows:
-
-```
-"start": "SET NODE_ENV=production & ts-node --transpile-only src/server.ts",
-"dev": "SET NODE_ENV=development & nodemon --watch src --delay 1 --exec ts-node src/server.ts",
-```
-
 ## ⛑ Code Structure (default)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -122,3 +122,5 @@ You may need to install [nodemon](https://www.npmjs.com/package/nodemon) separat
 * BitYoungjae [https://github.com/BitYoungjae](https://github.com/BitYoungjae)
 
 * strama4 [https://github.com/strama4](https://github.com/strama4)
+
+* João Silva [https://github.com/joaopms](https://github.com/joaopms)

--- a/typescript-express-starter/README.md
+++ b/typescript-express-starter/README.md
@@ -57,13 +57,6 @@ $ cd "project name" && npm run start
 
 You may need to install [nodemon](https://www.npmjs.com/package/nodemon) separately if you do not currently have it installed on your machine.
 
-NOTE: If you are running this on a Windows machine, you will need to update the `npm run start` and `npm run dev` script commands as follows:
-
-```
-"start": "SET NODE_ENV=production & ts-node --transpile-only src/server.ts",
-"dev": "SET NODE_ENV=development & nodemon --watch src --delay 1 --exec ts-node src/server.ts",
-```
-
 ## ⛑ Code Structure (default)
 
 ```bash

--- a/typescript-express-starter/README.md
+++ b/typescript-express-starter/README.md
@@ -122,3 +122,5 @@ You may need to install [nodemon](https://www.npmjs.com/package/nodemon) separat
 * BitYoungjae [https://github.com/BitYoungjae](https://github.com/BitYoungjae)
 
 * strama4 [https://github.com/strama4](https://github.com/strama4)
+
+* João Silva [https://github.com/joaopms](https://github.com/joaopms)

--- a/typescript-express-starter/lib/default/package.json
+++ b/typescript-express-starter/lib/default/package.json
@@ -4,8 +4,8 @@
   "description": "typescript-express-starter-default",
   "license": "ISC",
   "scripts": {
-    "start": "NODE_ENV=production ts-node --transpile-only src/server.ts",
-    "dev": "NODE_ENV=development nodemon --watch src --delay 1 --exec 'ts-node' src/server.ts",
+    "start": "cross-env NODE_ENV=production ts-node --transpile-only src/server.ts",
+    "dev": "cross-env NODE_ENV=development nodemon --watch src --delay 1 --exec 'ts-node' src/server.ts",
     "test": "jest --forceExit --detectOpenHandles",
     "lint": "tslint -p tsconfig.json -c tslint.json"
   }

--- a/typescript-express-starter/lib/mongoose/package.json
+++ b/typescript-express-starter/lib/mongoose/package.json
@@ -4,8 +4,8 @@
   "description": "typescript-express-starter-mongoose",
   "license": "ISC",
   "scripts": {
-    "start": "NODE_ENV=production ts-node --transpile-only src/server.ts",
-    "dev": "NODE_ENV=development nodemon --watch src --delay 1 --exec 'ts-node' src/server.ts",
+    "start": "cross-env NODE_ENV=production ts-node --transpile-only src/server.ts",
+    "dev": "cross-env NODE_ENV=development nodemon --watch src --delay 1 --exec 'ts-node' src/server.ts",
     "test": "jest --forceExit --detectOpenHandles",
     "lint": "tslint -p tsconfig.json -c tslint.json"
   }

--- a/typescript-express-starter/lib/typescript-express-starter.js
+++ b/typescript-express-starter/lib/typescript-express-starter.js
@@ -84,7 +84,7 @@ async function updatePackageJson(destination) {
 
 async function getDependencies(directory) {
   let dependencies =
-    'class-transformer class-validator cors envalid express helmet hpp jest morgan ts-jest ts-node typescript';
+    'class-transformer class-validator cors envalid express helmet hpp jest morgan ts-jest ts-node typescript cross-env';
   let devDependencies =
     '@types/cors @types/express @types/helmet @types/hpp @types/jest @types/morgan @types/node @types/supertest supertest tslint tslint-config-airbnb';
 


### PR DESCRIPTION
By using `cross-env` there's no need to change the `package.json` if the user is using a Windows machine like #13 suggested, providing a better user experience.