### PR TITLE
Addreessed this issue: src/app.ts:40:20 - error TS2349: This expressi…

### DIFF
--- a/lib/default/src/app.ts
+++ b/lib/default/src/app.ts
@@ -1,7 +1,7 @@
 import * as cookieParser from 'cookie-parser';
 import * as cors from 'cors';
 import * as express from 'express';
-import * as helmet from 'helmet';
+import helmet from 'helmet';
 import * as hpp from 'hpp';
 import * as logger from 'morgan';
 import Routes from './interfaces/routes.interface';

--- a/lib/mongoose/src/app.ts
+++ b/lib/mongoose/src/app.ts
@@ -1,7 +1,7 @@
 import * as cookieParser from 'cookie-parser';
 import * as cors from 'cors';
 import * as express from 'express';
-import * as helmet from 'helmet';
+import helmet from 'helmet';
 import * as hpp from 'hpp';
 import * as mongoose from 'mongoose';
 import * as logger from 'morgan';

--- a/lib/sequelize/src/app.ts
+++ b/lib/sequelize/src/app.ts
@@ -1,7 +1,7 @@
 import * as cookieParser from 'cookie-parser';
 import * as cors from 'cors';
 import * as express from 'express';
-import * as helmet from 'helmet';
+import helmet from 'helmet';
 import * as hpp from 'hpp';
 import * as logger from 'morgan';
 import Routes from './interfaces/routes.interface';


### PR DESCRIPTION
Had problem with "helmet is not callable."  in app.ts; seems to be an issue with latest version of typescript. 
Very simple fix.  


src/app.ts:40:20 - error TS2349: This expression is not callable.

  Type 'typeof import(".../node_modules/helmet/dist/index")' has no call signatures.

40       this.app.use(helmet());

****

Tested default and mongoose build.
(Other problems exist for sequelize) 