### PR TITLE
Fix Bug [DELETE] /users/:id test returns 500

### DIFF
--- a/lib/prisma/src/tests/users.test.ts
+++ b/lib/prisma/src/tests/users.test.ts
@@ -108,14 +108,18 @@ describe('Testing Users', () => {
   describe('[DELETE] /users/:id', () => {
     it('response Delete user', async () => {
       const userId = 1;
-
+      const userData: CreateUserDto = {
+        email: 'test@email.com',
+        password: 'q1w2e3r4',
+      };
+      
       const usersRoute = new UserRoute();
       const users = usersRoute.usersController.userService.users;
 
       users.findUnique = jest.fn().mockReturnValue({
         id: userId,
-        email: 'a@email.com',
-        password: await bcrypt.hash('q1w2e3r4!', 10),
+        email: userData.email,
+        password: await bcrypt.hash(userData.password, 10),
       });    
       users.delete = jest.fn().mockReturnValue({
         id: userId,

--- a/lib/prisma/src/tests/users.test.ts
+++ b/lib/prisma/src/tests/users.test.ts
@@ -116,6 +116,11 @@ describe('Testing Users', () => {
         id: userId,
         email: 'a@email.com',
         password: await bcrypt.hash('q1w2e3r4!', 10),
+      });    
+      users.delete = jest.fn().mockReturnValue({
+        id: userId,
+        email: userData.email,
+        password: await bcrypt.hash(userData.password, 10),
       });
 
       const app = new App([usersRoute]);


### PR DESCRIPTION
## Content (작업 내용)

[DELETE] /users/:id test returns 500, expected 200

```sh
● Testing Users › [DELETE] /users/:id › response Delete user

    expected 200 "OK", got 500 "Internal Server Error"

      131 |
      132 |       const app = new App([usersRoute]);
    > 133 |       return request(app.getServer()).delete(`${usersRoute.path}/${userId}`).expect(200);
          |                                                                              ^
      134 |     });
      135 |   });
      136 | });
```
More detailed error 
```sh
[DELETE] /users/1 >> StatusCode:: 500, Message:: 
Invalid `prisma.user.delete()` invocation:
      
An operation failed because it depends on one or more records that were required but not found. Record to delete does not exist.
```

missing `delete` mockReturnValue

## Check List (체크 사항)

<!-- to check an item, place an "x" in the box -->

- [ ] Issue (이슈)
- [x] Tests (테스트)
- [x] Ready to be merged (병합 준비 완료)
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table (기여자 추가)
      <!-- this is optional, see the contributing guidelines for instructions -->
