### PR TITLE
Use `6.2.3` as the mongoose version for typegoose template

### DIFF
--- a/lib/typegoose/package.json
+++ b/lib/typegoose/package.json
@@ -29,7 +29,7 @@
     "helmet": "^4.6.0",
     "hpp": "^0.2.3",
     "jsonwebtoken": "^8.5.1",
-    "mongoose": "~6.1.3",
+    "mongoose": "~6.2.3",
     "morgan": "^1.10.0",
     "swagger-jsdoc": "^6.0.0",
     "swagger-ui-express": "^4.1.6",


### PR DESCRIPTION
Use `6.2.3` as the mongoose version to prevent getting error since  Typegoose requires you to use mongoose 6.2.3 or higher 

When a project is created with Typegoose being used as the template, \
it will give this error when you run it in debug mode (`npm run dev`):

```log
2022-03-07 15:14:26 error: uncaughtException: Please use mongoose 6.2.3 or higher (Current mongoose: 6.1.10) [E001]
Error: Please use mongoose 6.2.3 or higher (Current mongoose: 6.1.10) [E001]
    at Object.<anonymous> (C:\Users\Devi\Desktop\Coding\todo-list\node_modules\@typegoose\typegoose\src\typegoose.ts:12:11)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Object.require.extensions.<computed> [as .js] (C:\Program Files\nvm\v16.14.0\node_modules\ts-node\src\index.ts:1465:43)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (C:\Users\Devi\Desktop\Coding\todo-list\src\models\users.model.ts:1:1)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
```

By simply changing the version number in `package.json` file, the error could be avoided 