### PR TITLE
🌼 Update Version

### DIFF
--- a/lib/typegoose/package.json
+++ b/lib/typegoose/package.json
@@ -29,7 +29,7 @@
     "helmet": "^4.6.0",
     "hpp": "^0.2.3",
     "jsonwebtoken": "^8.5.1",
-    "mongoose": "~6.2.3",
+    "mongoose": "^6.3.2",
     "morgan": "^1.10.0",
     "swagger-jsdoc": "^6.0.0",
     "swagger-ui-express": "^4.1.6",


### PR DESCRIPTION
Project won't start because of the outdated mongoose version.

## Content (작업 내용) 📝

Just bumped Mongoose version to the latest

## Etc (기타 사항) 🔖

Error that I was getting:
`error: uncaughtException: Please use mongoose 6.3.0 or higher (Current mongoose: 6.2.11) [E001]`

## Check List (체크 사항) ✅

<!-- to check an item, place an "x" in the box -->
<!-- 항목을 확인하려면 상자에 "x"표시 -->

- [ ] Issue (이슈)
- [x] Tests (테스트)
- [x] Ready to be merged (병합 준비 완료)
- [ ] Added myself to contributors table (기여자 추가)
