### PR TITLE
Development

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -371,6 +371,8 @@ VSCode Extension에서 [REST Client](https://marketplace.visualstudio.com/items?
 
 - Tamzid Karim [Tamzid Karim](https://github.com/tamzidkarim)
 
+- Andrija Milojević [https://github.com/andrija29](https://github.com/andrija29)
+
 ## 💳 라이센스
 
 [MIT](LICENSE)

--- a/lib/typegoose/src/middlewares/validation.middleware.ts
+++ b/lib/typegoose/src/middlewares/validation.middleware.ts
@@ -1,4 +1,4 @@
-import { plainToClass } from 'class-transformer';
+import { plainToInstance } from 'class-transformer';
 import { validate, ValidationError } from 'class-validator';
 import { RequestHandler } from 'express';
 import { HttpException } from '@exceptions/HttpException';
@@ -11,9 +11,9 @@ const validationMiddleware = (
   forbidNonWhitelisted = true,
 ): RequestHandler => {
   return (req, res, next) => {
-    validate(plainToClass(type, req[value]), { skipMissingProperties, whitelist, forbidNonWhitelisted }).then((errors: ValidationError[]) => {
+    validate(plainToInstance(type, req[value]), { skipMissingProperties, whitelist, forbidNonWhitelisted }).then((errors: ValidationError[]) => {
       if (errors.length > 0) {
-        const message = errors.map((error: ValidationError) => Object.values(error.constraints)).join(', ');
+        const message = errors.map((error: ValidationError) => error.constraints ? Object.values(error.constraints) : error.children.map((error: ValidationError) => Object.values(error.constraints))).join(', ');
         next(new HttpException(400, message));
       } else {
         next();


### PR DESCRIPTION
## Content (작업 내용) 📝

-Improved validation middleware so now it can handle errors inside nested objects
-Changed depreciated function


## Problem & Solution(링크) 🔗

**Problem:**
If user was to validate nested objects inside the dto class (ValidateNested functionality of the class-validator package) our validator middleware would throw an following error: 

> UnhandledPromiseRejectionWarning: TypeError: Cannot convert undefined or null to object

**Reason:**
When there are problems within nested objects, main ValidationError object does not contain constraints property, instead it is present inside each ValidationError object inside children property of the parent ValidationError.

**Solution:**
Also map errors inside the children property.

## Etc (기타 사항) 🔖
Also, I took opportunity to migrate to the new plainToInstance function instead depreciated plainToClass function.

## Check List (체크 사항) ✅

<!-- to check an item, place an "x" in the box -->
<!-- 항목을 확인하려면 상자에 "x"표시 -->

- [x] Issue (이슈)
- [x] Tests (테스트)
- [x] Ready to be merged (병합 준비 완료)
- [x] Added myself to contributors table (기여자 추가)
