### PR TITLE
feat: call seeder

### DIFF
--- a/lib/sequelize/package.json
+++ b/lib/sequelize/package.json
@@ -13,9 +13,11 @@
     "lint": "eslint --ignore-path .gitignore --ext .ts src/",
     "lint:fix": "npm run lint -- --fix",
     "deploy:prod": "npm run build && pm2 start ecosystem.config.js --only prod",
-    "deploy:dev": "pm2 start ecosystem.config.js --only dev"
+    "deploy:dev": "pm2 start ecosystem.config.js --only dev",
+    "seeder": "ts-node -T src/utils/call.seeder.ts --seed"
   },
   "dependencies": {
+    "@faker-js/faker": "^7.6.0",
     "bcrypt": "^5.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",

--- a/lib/sequelize/src/databases/index.ts
+++ b/lib/sequelize/src/databases/index.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
-import { NODE_ENV, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_DATABASE } from '@config';
-import UserModel from '@models/users.model';
-import { logger } from '@utils/logger';
+import { NODE_ENV, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_DATABASE } from '../config/index';
+import UserModel from '../models/users.model';
+import { logger } from '../utils/logger';
 
 const sequelize = new Sequelize.Sequelize(DB_DATABASE, DB_USER, DB_PASSWORD, {
   dialect: 'mysql',

--- a/lib/sequelize/src/interfaces/seeder.interface.ts
+++ b/lib/sequelize/src/interfaces/seeder.interface.ts
@@ -1,0 +1,5 @@
+export declare interface SeederInterface {
+
+  run(): Promise<void>;
+
+}

--- a/lib/sequelize/src/libraries/seeder.ts
+++ b/lib/sequelize/src/libraries/seeder.ts
@@ -1,0 +1,13 @@
+import DB from '../databases/index';
+import { SeederInterface } from '../interfaces/seeder.interface';
+
+export class Seeder implements SeederInterface {
+  constructor() {
+    // connect to data base
+    DB.sequelize.sync({ force: false });
+  }
+
+  async run(): Promise<void> {
+    //
+  }
+}

--- a/lib/sequelize/src/seeders/user.seeder.ts
+++ b/lib/sequelize/src/seeders/user.seeder.ts
@@ -1,0 +1,26 @@
+import { faker } from '@faker-js/faker';
+import { Seeder } from '../libraries/seeder';
+import DB from '../databases/index';
+
+/*
+ *  in order to seeder work perfectly out of box
+ * you need import exact path and  avoid using aliases path  for import file
+ *
+ *  cmd : npm run seeder --seed=../seeders/user.seeder.ts
+ *  */
+
+export default class UserSeeder extends Seeder {
+  private model = DB.Users;
+
+
+  async run(): Promise<void> {
+    const dataSeed = {
+      email: faker.internet.email(),
+      password: faker.internet.password(),
+      createdAt: faker.date.recent(),
+      updatedAt: faker.date.future(),
+    };
+
+    await this.model.create(dataSeed);
+  }
+}

--- a/lib/sequelize/src/utils/call.seeder.ts
+++ b/lib/sequelize/src/utils/call.seeder.ts
@@ -1,0 +1,29 @@
+/* npm run seeder --seed=../seeders/file.seeder.ts */
+(async () => {
+  // get seed variable from  process.evn
+  const path = process.env.npm_config_seed;
+  if (!path) {
+    // check if seed exist
+    console.log('Ops: seed path is empty\n' + 'follow this structure to work correctly\n' + 'npm run seeder --seed=../seeders/file.seeder.ts');
+    process.exit();
+  } else if (path.search('.ts') == -1) {
+    // check if path is has file.ts
+    console.log('Ops this path is not contain seed file ');
+    process.exit();
+  }
+
+  // dynamically import file
+  const file = await import(path);
+  // create new instance of file
+  const myClass = new file.default();
+ // call run
+  console.log('Start Seeding : ' + process.env.npm_config_seed + '  \n');
+  await myClass.run();
+})()
+  .then(() => {
+    process.exit();
+  })
+  .catch(error => {
+    console.log('Ops Seeding get Error : \n ');
+    console.error(error);
+  });

--- a/lib/sequelize/src/utils/logger.ts
+++ b/lib/sequelize/src/utils/logger.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import winston from 'winston';
 import winstonDaily from 'winston-daily-rotate-file';
-import { LOG_DIR } from '@config';
+import { LOG_DIR } from '../config/index';
 
 // logs dir
 const logDir: string = join(__dirname, LOG_DIR);


### PR DESCRIPTION
Hi  i add new feature to  sequelize scaffolding which can be apply to other scaffolding too . (i ddi it for mongoose scaffolding)
this feature help user to create seed for datatbase.   all we have to todo 
`npm run seeder --seed=../seeders/user.seeder.ts`
that's all


attention:   in order to seeder work perfectly out of box  you need import exact path file and avoid using aliases path
 

