### PR TITLE
fix: resolve template directory from package path

### DIFF
--- a/bin/validators.js
+++ b/bin/validators.js
@@ -225,7 +225,7 @@ export function cleanTemplate(templatePath) {
  * Validate all templates in the templates directory
  */
 export function validateAllTemplates() {
-  const templatesDir = path.join(process.cwd(), 'templates');
+  const templatesDir = CONFIG.paths.templates;
   const results = {};
 
   if (!fs.existsSync(templatesDir)) {


### PR DESCRIPTION
Fixes template validation when the CLI is installed globally via npm. Previously, validation checked process.cwd()/templates, which fails when the command is run outside the package repository. This change resolves templates from the package path instead.